### PR TITLE
loadUrl is deprecated, use loadURL instead

### DIFF
--- a/main.js
+++ b/main.js
@@ -21,7 +21,7 @@ app.on('ready', function() {
         width: 368
     });
 
-    mainWindow.loadUrl('file://' + __dirname + '/app/index.html');
+    mainWindow.loadURL('file://' + __dirname + '/app/index.html');
 
     setGlobalShortcuts();
 });


### PR DESCRIPTION
:wave: hi @bojzi!

I found your [blog post on the electron guide](https://medium.com/developers-writing/building-a-desktop-application-with-electron-204203eeb658#.o592wyn0h), but noticed with a maybe more recent version of Electron that `loadUrl` has changed to being `loadURL`. This may effect your gists, blog posts, and all of the releases you have, but I figured we had to start somewhere!

Let me know if there's anything else I can do.
